### PR TITLE
12504: Getting network metrics from virtual network interface

### DIFF
--- a/env_stat_utility/cgroup_stat_file_exporter.py
+++ b/env_stat_utility/cgroup_stat_file_exporter.py
@@ -17,6 +17,8 @@ class CgroupStatFileExporter:
                 disk_usage_dict = {"io_stat": self.cgroup_stats.get_io_stat(),
                                    "io_pressure": self.cgroup_stats.get_io_pressure()}
                 stats_dict['disk_usage'] = disk_usage_dict
+            if self.requested_stats['network']:
+                stats_dict['network_usage'] = self.cgroup_stats.get_network_stat()
             with open(filename, 'w+') as f:
                 f.write(json.dumps(stats_dict, indent='\t'))
         except FileExistsError as e:

--- a/env_stat_utility/cgroup_stats.py
+++ b/env_stat_utility/cgroup_stats.py
@@ -1,6 +1,7 @@
 class CgroupStats:
-    def __init__(self, name):
+    def __init__(self, name, network_interface_name):
         self.name = name
+        self.network_interface_name = network_interface_name
 
     def get_cpu_usage(self):
         try:
@@ -84,18 +85,16 @@ class CgroupStats:
             print(f"Error reading IO pressure: {e}")
             return None
 
-    # Пока захардкодил рандомный сетевой интерфейс, который у меня есть.
-    # Когда будет готов интерфейс под процесс прокси, либо хардкодкожу имя интерфейса в путь к файлам, либо вынесу его в CgroupStats приватным полем
-    def get_network_stat(self, network_interface='wlp2s0'):
+    def get_network_stat(self):
         try:
             network_stats = {}
-            with open(f"/sys/class/net/{network_interface}/statistics/rx_bytes") as f:
+            with open(f"/sys/class/net/{self.network_interface_name}/statistics/rx_bytes") as f:
                 network_stats['bytes_received'] = int(f.read().strip())
-            with open(f"/sys/class/net/{network_interface}/statistics/tx_bytes") as f:
+            with open(f"/sys/class/net/{self.network_interface_name}/statistics/tx_bytes") as f:
                 network_stats['bytes_transmitted'] = int(f.read().strip())
             return network_stats
         except FileNotFoundError as e:
-            print(f"Network statistic files not found for network interface {network_interface}: {e}")
+            print(f"Network statistic files not found for network interface {self.network_interface_name}: {e}")
         except Exception as e:
             print(f"Error getting network statistics from interface: {e}")
             return None

--- a/env_stat_utility/cgroup_stats.py
+++ b/env_stat_utility/cgroup_stats.py
@@ -83,3 +83,19 @@ class CgroupStats:
         except Exception as e:
             print(f"Error reading IO pressure: {e}")
             return None
+
+    # Пока захардкодил рандомный сетевой интерфейс, который у меня есть.
+    # Когда будет готов интерфейс под процесс прокси, либо хардкодкожу имя интерфейса в путь к файлам, либо вынесу его в CgroupStats приватным полем
+    def get_network_stat(self, network_interface='wlp2s0'):
+        try:
+            network_stats = {}
+            with open(f"/sys/class/net/{network_interface}/statistics/rx_bytes") as f:
+                network_stats['bytes_received'] = int(f.read().strip())
+            with open(f"/sys/class/net/{network_interface}/statistics/tx_bytes") as f:
+                network_stats['bytes_transmitted'] = int(f.read().strip())
+            return network_stats
+        except FileNotFoundError as e:
+            print(f"Network statistic files not found for network interface {network_interface}: {e}")
+        except Exception as e:
+            print(f"Error getting network statistics from interface: {e}")
+            return None

--- a/env_stat_utility/env-get-stats.py
+++ b/env_stat_utility/env-get-stats.py
@@ -19,7 +19,7 @@ def main():
     args = parser.parse_args()
 
     if not args.interface_name:
-        parser.error(f"Error: the arguments '--interface_name' must be specified together")
+        parser.error(f"Error: the argument '--interface_name' is required")
 
     cgroup_stats = CgroupStats(args.env_name, args.interface_name)
 

--- a/env_stat_utility/env-get-stats.py
+++ b/env_stat_utility/env-get-stats.py
@@ -19,7 +19,7 @@ def main():
     args = parser.parse_args()
 
     if not args.interface_name:
-        parser.error(f"Error: the arguments '--network' and '--interface_name' must be specified together")
+        parser.error(f"Error: the arguments '--interface_name' must be specified together")
 
     cgroup_stats = CgroupStats(args.env_name, args.interface_name)
 

--- a/env_stat_utility/env-get-stats.py
+++ b/env_stat_utility/env-get-stats.py
@@ -13,11 +13,15 @@ def main():
     parser.add_argument('--memory', action='store_true', help='RAM usage')
     parser.add_argument('--disk', action='store_true', help='disk usage')
     parser.add_argument('--network', action='store_true', help='network usage (bytes transmitted and received)')
+    parser.add_argument('--interface_name', type=str, help='virtual network interface name')
     parser.add_argument('-w', '--watch', action='store_true', help='watch mode')
     parser.add_argument('-o', '--output', type=str, default='stats.json', help='output file (.json)')
     args = parser.parse_args()
 
-    cgroup_stats = CgroupStats(args.env_name)
+    if (args.network and not args.interface_name) or (args.interface_name and not args.network):
+        parser.error(f"Error: the arguments '--network' and '--interface_name' must be specified together")
+
+    cgroup_stats = CgroupStats(args.env_name, args.interface_name)
 
     requested_stats = {key: value for key, value in vars(args).items() if key in ['cpu', 'memory', 'disk', 'network']}
     if True in requested_stats.values():

--- a/env_stat_utility/env-get-stats.py
+++ b/env_stat_utility/env-get-stats.py
@@ -18,7 +18,7 @@ def main():
     parser.add_argument('-o', '--output', type=str, default='stats.json', help='output file (.json)')
     args = parser.parse_args()
 
-    if not args.network or not args.interface_name:
+    if args.network and not args.interface_name or args.interface_name and not args.network:
         parser.error(f"Error: the arguments '--network' and '--interface_name' must be specified together")
 
     cgroup_stats = CgroupStats(args.env_name, args.interface_name)

--- a/env_stat_utility/env-get-stats.py
+++ b/env_stat_utility/env-get-stats.py
@@ -18,7 +18,7 @@ def main():
     parser.add_argument('-o', '--output', type=str, default='stats.json', help='output file (.json)')
     args = parser.parse_args()
 
-    if (args.network and not args.interface_name) or (args.interface_name and not args.network):
+    if not args.network or not args.interface_name:
         parser.error(f"Error: the arguments '--network' and '--interface_name' must be specified together")
 
     cgroup_stats = CgroupStats(args.env_name, args.interface_name)

--- a/env_stat_utility/env-get-stats.py
+++ b/env_stat_utility/env-get-stats.py
@@ -18,7 +18,7 @@ def main():
     parser.add_argument('-o', '--output', type=str, default='stats.json', help='output file (.json)')
     args = parser.parse_args()
 
-    if args.network and not args.interface_name or args.interface_name and not args.network:
+    if not args.interface_name:
         parser.error(f"Error: the arguments '--network' and '--interface_name' must be specified together")
 
     cgroup_stats = CgroupStats(args.env_name, args.interface_name)

--- a/env_stat_utility/env-get-stats.py
+++ b/env_stat_utility/env-get-stats.py
@@ -12,13 +12,14 @@ def main():
     parser.add_argument('--cpu', action='store_true', help='CPU usage')
     parser.add_argument('--memory', action='store_true', help='RAM usage')
     parser.add_argument('--disk', action='store_true', help='disk usage')
+    parser.add_argument('--network', action='store_true', help='network usage (bytes transmitted and received)')
     parser.add_argument('-w', '--watch', action='store_true', help='watch mode')
     parser.add_argument('-o', '--output', type=str, default='stats.json', help='output file (.json)')
     args = parser.parse_args()
 
     cgroup_stats = CgroupStats(args.env_name)
 
-    requested_stats = {key: value for key, value in vars(args).items() if key in ['cpu', 'memory', 'disk']}
+    requested_stats = {key: value for key, value in vars(args).items() if key in ['cpu', 'memory', 'disk', 'network']}
     if True in requested_stats.values():
         if args.watch:
             printer = CursesCgroupStatPrinter(cgroup_stats, requested_stats)


### PR DESCRIPTION
- добавил функцию снятия статистики с сетевого интерфейса, пока без конкретики с какого именно интерфейса. Когда будет готов сетевой интерфейс для процесса прокси, статистика будет сниматься именно с этого интерфейса, то бишь с процесса прокси, привязанного к этому интерфейсу;
- из статистики пока только rx_bytes, tx_bytes (полученные и отправленные). При необходимости можно добавить другие метрики (есть спец. директория /sys/class/net/{iface}/statistics/, в которой есть вся стата с сетевого интерфейса iface)
![image](https://github.com/user-attachments/assets/fb8977ed-251f-4981-bf8d-862d276a91d1)